### PR TITLE
More excluded fs types

### DIFF
--- a/df/plugin.go
+++ b/df/plugin.go
@@ -84,6 +84,12 @@ var (
 		"securityfs",
 		"devpts",
 		"mqueue",
+		"hugetlbfs",
+		"nsfs",
+		"rpc_pipefs",
+		"devtmpfs",
+		"none",
+		"tmpfs",
 	}
 )
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -17,7 +17,7 @@ if [ -z "$TEST_SUITE" ]; then
 	TEST_SUITE=$1
 fi
 # Check validity
-if [ “$TEST_SUITE” != “unit” ]; then
+if [ "$TEST_SUITE" != "unit" ]; then
 	echo "Error; invalid TEST_SUITE (value must be one of 'unit'; received $TEST_SUITE)"
 	exit -1
 fi


### PR DESCRIPTION
When running in a docker environment where host filesystems are exposed to the container, there are  a lot of FS types which should be ignored in terms of metrics gathering

Note that the PR also include a "fix" for some badly encoded double-quote chars in test script
