### PR TITLE
Configurable excluded fs types

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,21 +99,26 @@ Create a task manifest file to use snap-plugin-collector-df plugin (exemplary fi
     "workflow": {
         "collect": {
             "metrics": {
-		        "/intel/procfs/filesystem/rootfs/space_free": {},
-                "/intel/procfs/filesystem/rootfs/space_reserved": {},
-                "/intel/procfs/filesystem/rootfs/inodes_percent_free": {},
-                "/intel/procfs/filesystem/rootfs/inodes_percent_used": {},
-                "/intel/procfs/filesystem/rootfs/device_name": {},
-                "/intel/procfs/filesystem/sys_fs_cgroup/inodes_used": {}
-           },
+                "/intel/procfs/filesystem/*/space_free": {},
+                "/intel/procfs/filesystem/*/space_reserved": {},
+                "/intel/procfs/filesystem/*/inodes_percent_free": {},
+                "/intel/procfs/filesystem/*/inodes_percent_used": {},
+                "/intel/procfs/filesystem/*/device_name": {},
+                "/intel/procfs/filesystem/*/inodes_used": {}
+            },
             "config": {
+                "/intel/procfs/filesystem": {
+                    "proc_path": "/proc",
+                    "excluded_fs_names": "/proc/sys/fs/binfmt_misc,/var/lib/docker/aufs",
+                    "excluded_fs_types": "proc,binfmt_misc,fuse.gvfsd-fuse,sysfs,cgroup,fusectl,pstore,debugfs,securityfs,devpts,mqueue,hugetlbfs,nsfs,rpc_pipefs,devtmpfs,none,tmpfs,aufs"
+                }
             },
             "process": null,
             "publish": [
                 {
                     "plugin_name": "file",
                     "config": {
-                        "file": "/tmp/published_df"
+                        "file": "/tmp/published_df.log"
                     }
                 }
             ]

--- a/df/plugin.go
+++ b/df/plugin.go
@@ -91,6 +91,7 @@ var (
 		"devtmpfs",
 		"none",
 		"tmpfs",
+		"aufs",
 	}
 )
 

--- a/df/plugin.go
+++ b/df/plugin.go
@@ -339,6 +339,7 @@ func Meta() *plugin.PluginMeta {
 		plugin.CollectorPluginType,
 		[]string{plugin.SnapGOBContentType},
 		[]string{plugin.SnapGOBContentType},
+		plugin.RoutingStrategy(plugin.StickyRouting),
 		plugin.ConcurrencyCount(1),
 	)
 }

--- a/df/plugin_test.go
+++ b/df/plugin_test.go
@@ -20,11 +20,9 @@ limitations under the License.
 package df
 
 import (
+	"errors"
 	"strings"
-	"sync"
 	"testing"
-
-	log "github.com/Sirupsen/logrus"
 
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/mock"
@@ -32,6 +30,8 @@ import (
 
 	"github.com/intelsdi-x/snap/control/plugin"
 	"github.com/intelsdi-x/snap/core"
+	"github.com/intelsdi-x/snap/core/cdata"
+	"github.com/intelsdi-x/snap/core/ctypes"
 )
 
 type DfPluginSuite struct {
@@ -71,63 +71,38 @@ func (dfp *DfPluginSuite) SetupSuite() {
 			IUse:       0.5,
 		},
 	}
-	mc.On("collect", "/proc").Return(dfms, nil)
+	mc.On("collect", "/proc", dfltInvalidFSTypes).Return(dfms, nil)
+	mc.On("collect", "/dummy", dfltInvalidFSTypes).Return(dfms, errors.New("Fake error"))
 	dfp.mockCollector = mc
 	dfp.cfg = plugin.ConfigType{}
 }
 
 func (dfp *DfPluginSuite) TestGetMetricTypes() {
-	Convey("Given df plugin is initialized", dfp.T(), func() {
-		dfPlg := dfCollector{
-			stats:            dfp.mockCollector,
-			logger:           log.New(),
-			initializedMutex: new(sync.Mutex),
-			proc_path:        "/proc",
-		}
+	Convey("Given df plugin is badly initialized", dfp.T(), func() {
+		dfPlg := NewDfCollector()
+		dfPlg.stats = dfp.mockCollector
+
+		node := cdata.NewNode()
+		node.AddItem("proc_path", ctypes.ConfigValueStr{Value: "/dummy"})
 
 		Convey("When list of available metrics is requested", func() {
 			mts := []plugin.MetricType{
 				plugin.MetricType{
 					Namespace_: core.NewNamespace("intel", "procfs", "filesystem", "rootfs", "space_free"),
-				},
-				plugin.MetricType{
-					Namespace_: core.NewNamespace("intel", "procfs", "filesystem", "big", "inodes_percent_free"),
+					Config_:    node,
 				},
 			}
 			metrics, err := dfPlg.CollectMetrics(mts)
-
-			Convey("Then no error should be reported", func() {
-				So(err, ShouldBeNil)
-			})
-
-			Convey("Then proper metrics are returned", func() {
-				metvals := map[string]interface{}{}
-				for _, m := range metrics {
-					stat := strings.Join(m.Namespace().Strings()[3:], "/")
-					metvals[stat] = m.Data()
-				}
-				So(len(metrics), ShouldEqual, 2)
-
-				val, ok := metvals["rootfs/space_free"]
-				So(ok, ShouldBeTrue)
-				So(val, ShouldNotBeNil)
-
-				val, ok = metvals["big/inodes_percent_free"]
-				So(ok, ShouldBeTrue)
-				So(val, ShouldNotBeNil)
+			Convey("Then error should be reported", func() {
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldContainSubstring, "no such file or directory")
+				So(metrics, ShouldBeNil)
 			})
 		})
 	})
-}
-
-func (dfp *DfPluginSuite) TestCollectMetrics() {
 	Convey("Given df plugin is initialized", dfp.T(), func() {
-		dfPlg := dfCollector{
-			stats:            dfp.mockCollector,
-			logger:           log.New(),
-			initializedMutex: new(sync.Mutex),
-			proc_path:        "/proc",
-		}
+		dfPlg := NewDfCollector()
+		dfPlg.stats = dfp.mockCollector
 
 		Convey("When values for given metrics are requested", func() {
 
@@ -162,6 +137,292 @@ func (dfp *DfPluginSuite) TestCollectMetrics() {
 	})
 }
 
+func (dfp *DfPluginSuite) TestCollectMetrics() {
+	Convey("Given df plugin is initialized", dfp.T(), func() {
+		dfPlg := NewDfCollector()
+		dfPlg.stats = dfp.mockCollector
+
+		Convey("When list of metrics is requested with too short namespace", func() {
+			mts := []plugin.MetricType{
+				plugin.MetricType{
+					Namespace_: core.NewNamespace("filesystem", "rootfs", "space_free"),
+				},
+			}
+			metrics, err := dfPlg.CollectMetrics(mts)
+
+			Convey("Then error should be reported", func() {
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldContainSubstring, "Wrong namespace length")
+				So(metrics, ShouldBeNil)
+			})
+		})
+
+		Convey("When list of specific metrics is requested", func() {
+			mts := []plugin.MetricType{
+				plugin.MetricType{
+					Namespace_: core.NewNamespace("intel", "procfs", "filesystem", "rootfs", "space_free"),
+				},
+				plugin.MetricType{
+					Namespace_: core.NewNamespace("intel", "procfs", "filesystem", "big", "inodes_percent_free"),
+				},
+			}
+			metrics, err := dfPlg.CollectMetrics(mts)
+
+			Convey("Then no error should be reported", func() {
+				So(err, ShouldBeNil)
+				So(metrics, ShouldNotBeNil)
+			})
+
+			Convey("Then proper metrics are returned", func() {
+				metvals := map[string]interface{}{}
+				for _, m := range metrics {
+					stat := strings.Join(m.Namespace().Strings()[3:], "/")
+					metvals[stat] = m.Data()
+				}
+				So(len(metrics), ShouldEqual, 2)
+
+				val, ok := metvals["rootfs/space_free"]
+				So(ok, ShouldBeTrue)
+				So(val, ShouldNotBeNil)
+
+				val, ok = metvals["big/inodes_percent_free"]
+				So(ok, ShouldBeTrue)
+				So(val, ShouldNotBeNil)
+			})
+		})
+
+		Convey("When one single available dynamic metrics is requested", func() {
+			mts := []plugin.MetricType{
+				plugin.MetricType{
+					Namespace_: core.NewNamespace("intel", "procfs", "filesystem", "*", "space_free"),
+				},
+			}
+			metrics, err := dfPlg.CollectMetrics(mts)
+
+			Convey("Then no error should be reported", func() {
+				So(err, ShouldBeNil)
+				So(metrics, ShouldNotBeNil)
+			})
+
+			Convey("Then proper metrics are returned", func() {
+				metvals := map[string]interface{}{}
+				for _, m := range metrics {
+					stat := strings.Join(m.Namespace().Strings()[3:], "/")
+					metvals[stat] = m.Data()
+				}
+
+				So(len(metrics), ShouldEqual, 2)
+
+				val, ok := metvals["rootfs/space_free"]
+				So(ok, ShouldBeTrue)
+				So(val, ShouldNotBeNil)
+
+				val, ok = metvals["big/space_free"]
+				So(ok, ShouldBeTrue)
+				So(val, ShouldNotBeNil)
+			})
+		})
+
+		Convey("When calling twice", func() {
+			mts := []plugin.MetricType{
+				plugin.MetricType{
+					Namespace_: core.NewNamespace("intel", "procfs", "filesystem", "rootfs", "space_free"),
+				},
+			}
+			metrics, err := dfPlg.CollectMetrics(mts)
+
+			Convey("Then no error should be reported", func() {
+				So(err, ShouldBeNil)
+				So(metrics, ShouldNotBeNil)
+			})
+
+			dfPlg.proc_path = "/dummy"
+			_, err = dfPlg.CollectMetrics(mts)
+
+			Convey("Then error should be reported", func() {
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldContainSubstring, "Fake error")
+			})
+		})
+	})
+}
+
+func (dfp *DfPluginSuite) TestCollect() {
+	Convey("Given df plugin is initialized", dfp.T(), func() {
+		dfPlg := NewDfCollector()
+
+		Convey("When called with non existing path", func() {
+			metrics, err := dfPlg.stats.collect("/dummy", []string{})
+
+			Convey("Then error should be reported", func() {
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldContainSubstring, "no such file or directory")
+				So(metrics, ShouldBeNil)
+			})
+		})
+
+		Convey("When called with existing path", func() {
+			metrics, err := dfPlg.stats.collect("/proc", []string{})
+
+			Convey("Then error should be reported", func() {
+				So(err, ShouldBeNil)
+				So(metrics, ShouldNotBeNil)
+			})
+		})
+	})
+}
+
+func (dfp *DfPluginSuite) TestHelperRoutines() {
+	Convey("Basically initialized", dfp.T(), func() {
+
+		Convey("Namespace", func() {
+
+			ns := createNamespace("element", "name")
+
+			Convey("Then no error should be reported", func() {
+				So(ns, ShouldNotBeNil)
+				So(strings.Join(ns, ","), ShouldStartWith,
+					strings.Join(namespacePrefix, ","))
+				So(strings.Join(ns, ","), ShouldEndWith,
+					"element,name")
+			})
+
+			dfm := dfMetric{
+				MountPoint: "/mount",
+			}
+			ns = makeNamespace(dfm, "mykind")
+
+			Convey("Then namespace shoud be reported", func() {
+				So(ns, ShouldNotBeNil)
+				So(len(ns), ShouldNotEqual, 0)
+				So(ns[len(ns)-1], ShouldEqual, "mykind")
+				So(ns[len(ns)-2], ShouldEqual, "/mount")
+			})
+		})
+
+		Convey("Set config variables", func() {
+
+			node := cdata.NewNode()
+			node.AddItem("proc_path", ctypes.ConfigValueStr{Value: "/etc/hosts"})
+			cfg := plugin.ConfigType{ConfigDataNode: node}
+			dfPlg := NewDfCollector()
+			dfPlg.stats = dfp.mockCollector
+			err := dfPlg.setProcPath(cfg)
+
+			Convey("Then error should be reported (not a directory)", func() {
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldContainSubstring, "is not a directory")
+			})
+
+			node = cdata.NewNode()
+			node.AddItem("proc_path", ctypes.ConfigValueStr{Value: "/proc"})
+			cfg = plugin.ConfigType{ConfigDataNode: node}
+			dfPlg = NewDfCollector()
+			dfPlg.stats = dfp.mockCollector
+			err = dfPlg.setProcPath(cfg)
+
+			Convey("Then no error should be reported (proc_path)", func() {
+				So(err, ShouldBeNil)
+			})
+
+			err = dfPlg.setProcPath(cfg)
+
+			Convey("Then no error should be reported (already called)", func() {
+				So(err, ShouldBeNil)
+				So(len(dfPlg.invalid_fs_types), ShouldEqual, 17)
+			})
+
+			node = cdata.NewNode()
+			node.AddItem("invalid_fs_types", ctypes.ConfigValueStr{Value: ""})
+			dfPlg = NewDfCollector()
+			dfPlg.stats = dfp.mockCollector
+			cfg = plugin.ConfigType{ConfigDataNode: node}
+			err = dfPlg.setProcPath(cfg)
+
+			Convey("Then no error should be reported (invalid_fs_types with proper value for empty string)", func() {
+				So(err, ShouldBeNil)
+				So(len(dfPlg.invalid_fs_types), ShouldEqual, 0)
+			})
+
+			node = cdata.NewNode()
+			node.AddItem("invalid_fs_types", ctypes.ConfigValueStr{Value: "fs1,fs2"})
+			dfPlg = NewDfCollector()
+			dfPlg.stats = dfp.mockCollector
+			cfg = plugin.ConfigType{ConfigDataNode: node}
+			err = dfPlg.setProcPath(cfg)
+
+			Convey("Then no error should be reported (invalid_fs_types with proper value)", func() {
+				So(err, ShouldBeNil)
+				So(len(dfPlg.invalid_fs_types), ShouldEqual, 2)
+			})
+		})
+
+		Convey("Set get config policy", func() {
+
+			dfPlg := NewDfCollector()
+			dfPlg.stats = dfp.mockCollector
+			cp, err := dfPlg.GetConfigPolicy()
+
+			Convey("Then no error should be reported", func() {
+				So(err, ShouldBeNil)
+				So(cp, ShouldNotBeNil)
+			})
+		})
+
+		Convey("Miscellaneous", func() {
+
+			dfm := dfMetric{
+				MountPoint: "/mount",
+			}
+			v := validateMetric([]string{"/mount"}, dfm)
+
+			Convey("Then true value should be reported", func() {
+				So(v, ShouldEqual, true)
+			})
+
+			v = validateMetric([]string{"/test"}, dfm)
+
+			Convey("Then false value should be reported", func() {
+				So(v, ShouldEqual, false)
+			})
+
+			l := []string{"1", "2", "3", "4"}
+			v = invalidFSType("3", l)
+
+			Convey("Then value should be reported as found", func() {
+				So(v, ShouldEqual, true)
+			})
+
+			v = invalidFSType("error", l)
+
+			Convey("Then value should be reported as not found", func() {
+				So(v, ShouldEqual, false)
+			})
+
+			m := Meta()
+
+			Convey("Then meta value should be reported as not nil", func() {
+				So(m, ShouldNotBeNil)
+			})
+		})
+
+		Convey("ceilPercent", func() {
+
+			v := ceilPercent(1, 0)
+
+			Convey("Then 0.0 value should be reported", func() {
+				So(v, ShouldEqual, 0.0)
+			})
+
+			v = ceilPercent(80, 111)
+
+			Convey("Then x value should be reported", func() {
+				So(v, ShouldEqual, 73.0)
+			})
+		})
+	})
+}
+
 func TestDfPluginSuite(t *testing.T) {
 	suite.Run(t, &DfPluginSuite{})
 }
@@ -170,7 +431,7 @@ type MockCollector struct {
 	mock.Mock
 }
 
-func (mc *MockCollector) collect(p string) ([]dfMetric, error) {
-	ret := mc.Mock.Called("/proc")
+func (mc *MockCollector) collect(p string, i []string) ([]dfMetric, error) {
+	ret := mc.Mock.Called(p, i)
 	return ret.Get(0).([]dfMetric), ret.Error(1)
 }

--- a/df/plugin_test.go
+++ b/df/plugin_test.go
@@ -21,7 +21,10 @@ package df
 
 import (
 	"strings"
+	"sync"
 	"testing"
+
+	log "github.com/Sirupsen/logrus"
 
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/mock"
@@ -76,7 +79,10 @@ func (dfp *DfPluginSuite) SetupSuite() {
 func (dfp *DfPluginSuite) TestGetMetricTypes() {
 	Convey("Given df plugin is initialized", dfp.T(), func() {
 		dfPlg := dfCollector{
-			stats: dfp.mockCollector,
+			stats:            dfp.mockCollector,
+			logger:           log.New(),
+			initializedMutex: new(sync.Mutex),
+			proc_path:        "/proc",
 		}
 
 		Convey("When list of available metrics is requested", func() {
@@ -117,7 +123,10 @@ func (dfp *DfPluginSuite) TestGetMetricTypes() {
 func (dfp *DfPluginSuite) TestCollectMetrics() {
 	Convey("Given df plugin is initialized", dfp.T(), func() {
 		dfPlg := dfCollector{
-			stats: dfp.mockCollector,
+			stats:            dfp.mockCollector,
+			logger:           log.New(),
+			initializedMutex: new(sync.Mutex),
+			proc_path:        "/proc",
 		}
 
 		Convey("When values for given metrics are requested", func() {

--- a/df/plugin_test.go
+++ b/df/plugin_test.go
@@ -436,7 +436,7 @@ func (dfp *DfPluginSuite) TestHelperRoutines() {
 
 			Convey("Then no error should be reported (already called)", func() {
 				So(err, ShouldBeNil)
-				So(len(dfPlg.invalid_fs_types), ShouldEqual, 17)
+				So(len(dfPlg.invalid_fs_types), ShouldEqual, 18)
 			})
 
 			node = cdata.NewNode()

--- a/df/plugin_test.go
+++ b/df/plugin_test.go
@@ -71,8 +71,8 @@ func (dfp *DfPluginSuite) SetupSuite() {
 			IUse:       0.5,
 		},
 	}
-	mc.On("collect", "/proc", dfltInvalidFSTypes).Return(dfms, nil)
-	mc.On("collect", "/dummy", dfltInvalidFSTypes).Return(dfms, errors.New("Fake error"))
+	mc.On("collect", "/proc", dfltExcludedFSTypes).Return(dfms, nil)
+	mc.On("collect", "/dummy", dfltExcludedFSTypes).Return(dfms, errors.New("Fake error"))
 	dfp.mockCollector = mc
 	dfp.cfg = plugin.ConfigType{}
 }
@@ -436,31 +436,31 @@ func (dfp *DfPluginSuite) TestHelperRoutines() {
 
 			Convey("Then no error should be reported (already called)", func() {
 				So(err, ShouldBeNil)
-				So(len(dfPlg.invalid_fs_types), ShouldEqual, 18)
+				So(len(dfPlg.excluded_fs_types), ShouldEqual, 18)
 			})
 
 			node = cdata.NewNode()
-			node.AddItem("invalid_fs_types", ctypes.ConfigValueStr{Value: ""})
+			node.AddItem("excluded_fs_types", ctypes.ConfigValueStr{Value: ""})
 			dfPlg = NewDfCollector()
 			dfPlg.stats = dfp.mockCollector
 			cfg = plugin.ConfigType{ConfigDataNode: node}
 			err = dfPlg.setProcPath(cfg)
 
-			Convey("Then no error should be reported (invalid_fs_types with proper value for empty string)", func() {
+			Convey("Then no error should be reported (excluded_fs_types with proper value for empty string)", func() {
 				So(err, ShouldBeNil)
-				So(len(dfPlg.invalid_fs_types), ShouldEqual, 0)
+				So(len(dfPlg.excluded_fs_types), ShouldEqual, 0)
 			})
 
 			node = cdata.NewNode()
-			node.AddItem("invalid_fs_types", ctypes.ConfigValueStr{Value: "fs1,fs2"})
+			node.AddItem("excluded_fs_types", ctypes.ConfigValueStr{Value: "fs1,fs2"})
 			dfPlg = NewDfCollector()
 			dfPlg.stats = dfp.mockCollector
 			cfg = plugin.ConfigType{ConfigDataNode: node}
 			err = dfPlg.setProcPath(cfg)
 
-			Convey("Then no error should be reported (invalid_fs_types with proper value)", func() {
+			Convey("Then no error should be reported (excluded_fs_types with proper value)", func() {
 				So(err, ShouldBeNil)
-				So(len(dfPlg.invalid_fs_types), ShouldEqual, 2)
+				So(len(dfPlg.excluded_fs_types), ShouldEqual, 2)
 			})
 		})
 
@@ -494,13 +494,13 @@ func (dfp *DfPluginSuite) TestHelperRoutines() {
 			})
 
 			l := []string{"1", "2", "3", "4"}
-			v = invalidFSType("3", l)
+			v = excludedFSType("3", l)
 
 			Convey("Then value should be reported as found", func() {
 				So(v, ShouldEqual, true)
 			})
 
-			v = invalidFSType("error", l)
+			v = excludedFSType("error", l)
 
 			Convey("Then value should be reported as not found", func() {
 				So(v, ShouldEqual, false)

--- a/df/plugin_test.go
+++ b/df/plugin_test.go
@@ -82,7 +82,7 @@ func (dfp *DfPluginSuite) TestGetMetricTypes() {
 		dfPlg.stats = dfp.mockCollector
 
 		node := cdata.NewNode()
-		node.AddItem("proc_path", ctypes.ConfigValueStr{Value: "/dummy"})
+		node.AddItem(ProcPath, ctypes.ConfigValueStr{Value: "/dummy"})
 
 		Convey("When list of available metrics is requested", func() {
 			mts := []plugin.MetricType{
@@ -425,7 +425,7 @@ func (dfp *DfPluginSuite) TestHelperRoutines() {
 		Convey("Set config variables", func() {
 
 			node := cdata.NewNode()
-			node.AddItem("proc_path", ctypes.ConfigValueStr{Value: "/etc/hosts"})
+			node.AddItem(ProcPath, ctypes.ConfigValueStr{Value: "/etc/hosts"})
 			cfg := plugin.ConfigType{ConfigDataNode: node}
 			dfPlg := NewDfCollector()
 			dfPlg.stats = dfp.mockCollector
@@ -437,7 +437,7 @@ func (dfp *DfPluginSuite) TestHelperRoutines() {
 			})
 
 			node = cdata.NewNode()
-			node.AddItem("proc_path", ctypes.ConfigValueStr{Value: "/proc"})
+			node.AddItem(ProcPath, ctypes.ConfigValueStr{Value: "/proc"})
 			cfg = plugin.ConfigType{ConfigDataNode: node}
 			dfPlg = NewDfCollector()
 			dfPlg.stats = dfp.mockCollector
@@ -456,7 +456,7 @@ func (dfp *DfPluginSuite) TestHelperRoutines() {
 			})
 
 			node = cdata.NewNode()
-			node.AddItem("excluded_fs_names", ctypes.ConfigValueStr{Value: ""})
+			node.AddItem(ExcludedFSNames, ctypes.ConfigValueStr{Value: ""})
 			dfPlg = NewDfCollector()
 			dfPlg.stats = dfp.mockCollector
 			cfg = plugin.ConfigType{ConfigDataNode: node}
@@ -468,7 +468,7 @@ func (dfp *DfPluginSuite) TestHelperRoutines() {
 			})
 
 			node = cdata.NewNode()
-			node.AddItem("excluded_fs_names", ctypes.ConfigValueStr{Value: "n1,n2,n3"})
+			node.AddItem(ExcludedFSNames, ctypes.ConfigValueStr{Value: "n1,n2,n3"})
 			dfPlg = NewDfCollector()
 			dfPlg.stats = dfp.mockCollector
 			cfg = plugin.ConfigType{ConfigDataNode: node}
@@ -480,7 +480,7 @@ func (dfp *DfPluginSuite) TestHelperRoutines() {
 			})
 
 			node = cdata.NewNode()
-			node.AddItem("excluded_fs_types", ctypes.ConfigValueStr{Value: ""})
+			node.AddItem(ExcludedFSTypes, ctypes.ConfigValueStr{Value: ""})
 			dfPlg = NewDfCollector()
 			dfPlg.stats = dfp.mockCollector
 			cfg = plugin.ConfigType{ConfigDataNode: node}
@@ -492,7 +492,7 @@ func (dfp *DfPluginSuite) TestHelperRoutines() {
 			})
 
 			node = cdata.NewNode()
-			node.AddItem("excluded_fs_types", ctypes.ConfigValueStr{Value: "fs1,fs2"})
+			node.AddItem(ExcludedFSTypes, ctypes.ConfigValueStr{Value: "fs1,fs2"})
 			dfPlg = NewDfCollector()
 			dfPlg.stats = dfp.mockCollector
 			cfg = plugin.ConfigType{ConfigDataNode: node}

--- a/examples/task/df-file.json
+++ b/examples/task/df-file.json
@@ -17,7 +17,7 @@
             "config": {
                 "/intel/procfs/filesystem": {
                     "proc_path": "/proc",
-                    "invalid_fs_types": "proc,binfmt_misc,fuse.gvfsd-fuse,sysfs,cgroup,fusectl,pstore,debugfs,securityfs,devpts,mqueue,hugetlbfs,nsfs,rpc_pipefs,devtmpfs,none,tmpfs,aufs"
+                    "excluded_fs_types": "proc,binfmt_misc,fuse.gvfsd-fuse,sysfs,cgroup,fusectl,pstore,debugfs,securityfs,devpts,mqueue,hugetlbfs,nsfs,rpc_pipefs,devtmpfs,none,tmpfs,aufs"
                 }
             },
             "process": null,

--- a/examples/task/df-file.json
+++ b/examples/task/df-file.json
@@ -17,7 +17,7 @@
             "config": {
                 "/intel/procfs/filesystem": {
                     "proc_path": "/proc",
-                    "invalid_fs_types": "proc,binfmt_misc,fuse.gvfsd-fuse,sysfs,cgroup,fusectl,pstore,debugfs,securityfs,devpts,mqueue,hugetlbfs,nsfs,rpc_pipefs,devtmpfs,none,tmpfs"
+                    "invalid_fs_types": "proc,binfmt_misc,fuse.gvfsd-fuse,sysfs,cgroup,fusectl,pstore,debugfs,securityfs,devpts,mqueue,hugetlbfs,nsfs,rpc_pipefs,devtmpfs,none,tmpfs,aufs"
                 }
             },
             "process": null,

--- a/examples/task/df-file.json
+++ b/examples/task/df-file.json
@@ -16,7 +16,8 @@
             },
             "config": {
                 "/intel/procfs/filesystem": {
-                    "proc_path": "/proc"
+                    "proc_path": "/proc",
+                    "invalid_fs_types": "proc,binfmt_misc,fuse.gvfsd-fuse,sysfs,cgroup,fusectl,pstore,debugfs,securityfs,devpts,mqueue,hugetlbfs,nsfs,rpc_pipefs,devtmpfs,none,tmpfs"
                 }
             },
             "process": null,

--- a/examples/task/df-file.json
+++ b/examples/task/df-file.json
@@ -17,6 +17,7 @@
             "config": {
                 "/intel/procfs/filesystem": {
                     "proc_path": "/proc",
+                    "excluded_fs_names": "/proc/sys/fs/binfmt_misc,/var/lib/docker/aufs",
                     "excluded_fs_types": "proc,binfmt_misc,fuse.gvfsd-fuse,sysfs,cgroup,fusectl,pstore,debugfs,securityfs,devpts,mqueue,hugetlbfs,nsfs,rpc_pipefs,devtmpfs,none,tmpfs,aufs"
                 }
             },


### PR DESCRIPTION
Fixes #19: Potential thread safety issue during initialisation of plugin

also added the following 

Summary of changes:
-  Add config option for excluded filesystems types list
-  Fixed test execution
- Added more tests for better coverage

Testing done:
- ran both unit and legacy

