### PR TITLE
Fix for issue #10: Namespace ambiguity issue for filesystem mount point part of metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Create a task manifest file to use snap-plugin-collector-df plugin (exemplary fi
             "config": {
                 "/intel/procfs/filesystem": {
                     "proc_path": "/proc",
+                    "keep_original_mountpoint": true,
                     "excluded_fs_names": "/proc/sys/fs/binfmt_misc,/var/lib/docker/aufs",
                     "excluded_fs_types": "proc,binfmt_misc,fuse.gvfsd-fuse,sysfs,cgroup,fusectl,pstore,debugfs,securityfs,devpts,mqueue,hugetlbfs,nsfs,rpc_pipefs,devtmpfs,none,tmpfs,aufs"
                 }

--- a/examples/task/df-file.json
+++ b/examples/task/df-file.json
@@ -17,6 +17,7 @@
             "config": {
                 "/intel/procfs/filesystem": {
                     "proc_path": "/proc",
+                    "keep_original_mountpoint": true,
                     "excluded_fs_names": "/proc/sys/fs/binfmt_misc,/var/lib/docker/aufs",
                     "excluded_fs_types": "proc,binfmt_misc,fuse.gvfsd-fuse,sysfs,cgroup,fusectl,pstore,debugfs,securityfs,devpts,mqueue,hugetlbfs,nsfs,rpc_pipefs,devtmpfs,none,tmpfs,aufs"
                 }


### PR DESCRIPTION
Fixes #10 
Add configurable option for keeping unchanged mountpoints in returned metrics

Summary of changes:
- add configurable option
- tests modified accordingly

How to verify it:
- activating the option and passing data to heka publisher and looking into grafana just work perfectly

Testing done:
- small & legacy test passed

