### PR TITLE
Renamed folder `task` to `tasks` to be consistent with README

### DIFF
--- a/examples/tasks/df-file.json
+++ b/examples/tasks/df-file.json
@@ -25,7 +25,7 @@
             "process": null,
             "publish": [
                 {
-                    "plugin_name": "mock-file",
+                    "plugin_name": "file",
                     "config": {
                         "file": "/tmp/published_df.log"
                     }


### PR DESCRIPTION
Fixes invalid links in README.md

Summary of changes:
- renamed folder `task` to `tasks` to be consistent with README
- changes in task manifest - switch from mock-file publisher to file publisher


